### PR TITLE
Adding unit tests to the GitHub Actions

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,0 +1,31 @@
+name: Unit Tests
+on:
+    push:
+        branches:
+        - main
+    pull_request:
+
+jobs:
+    pytest:
+        name: Pytest Ubuntu20
+        runs-on: ubuntu-20.04
+        steps:
+        - uses: actions/checkout@v2
+        - name: "Build and Test"
+          run: |
+              # grab a recent Miniconda install script (Python 3.9 or newer)
+              curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+              # build Miniconda locally into a directory named "miniforge3"
+              bash ./Miniforge3-*.sh -b -p miniforge3
+              # activate the Miniconda env
+              source miniforge3/bin/activate root
+              # install a bunch of stuff pyopencl needs
+              conda install pytest -y
+              conda install matplotlib -y
+              conda install pyopencl -y
+              conda install pocl -y
+              conda install ocl-icd-system -y
+              conda install oclgrind -y
+              # run the unit tests
+              python -m pytest tests/src/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+**/__pycache__
+*.py[cod]
+
+# Cython and C extensions
+*.so
+*.c
+*.h
+*.html
+
+# Distribution / packaging
+.Python
+env/
+venv/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+miniforge3/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+cover/
+.cache
+.idea/
+.miniforge3
+siteconf.py
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+


### PR DESCRIPTION
Adding the unit tests to the GitHub Actions workflows.

For the sake of simplifying the installation, this workflow runs the unit tests inside an Anaconda environment. To speed up the installation, I chose Miniconda (which installs an Anaconda env with a reduced number of third-party libraries).  Because the `setup.cfg` requires either Python 3.9.x or Python 3.10.x, I choose Ubuntu-20.04 for the test OS, as that comes with Python 3.9.

I would, of course, be happy to tweak some of the implementation details for this PR. But it does the primary thing, which is it automates running unit tests for every PR (or change) into the `main` branch.